### PR TITLE
fix: Matrix.decompose doesn't mutate input parameters correctly

### DIFF
--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -2239,20 +2239,29 @@ export namespace Matrix {
   ): boolean {
     if (self.isIdentity) {
       if (translation) {
-        translation = Vector3.create(0, 0, 0)
+        translation.x = 0
+        translation.y = 0
+        translation.z = 0
       }
       if (scale) {
-        scale = Vector3.create(0, 0, 0)
+        scale.x = 1
+        scale.y = 1
+        scale.z = 1
       }
       if (rotation) {
-        rotation = Quaternion.create(0, 0, 0, 1)
+        rotation.w = 1
+        rotation.x = 0
+        rotation.y = 0
+        rotation.z = 0
       }
       return true
     }
 
     const m = self._m
     if (translation) {
-      translation = Vector3.create(m[12], m[13], m[14])
+      translation.x = m[12]
+      translation.y = m[13]
+      translation.z = m[14]
     }
 
     const usedScale = scale || Vector3.Zero()
@@ -2266,7 +2275,10 @@ export namespace Matrix {
 
     if (usedScale.x === 0 || usedScale.y === 0 || usedScale.z === 0) {
       if (rotation) {
-        rotation = Quaternion.create(0, 0, 0, 1)
+        rotation.w = 1
+        rotation.x = 0
+        rotation.y = 0
+        rotation.z = 0
       }
       return false
     }

--- a/test/matrix.spec.ts
+++ b/test/matrix.spec.ts
@@ -1,3 +1,4 @@
+import { Epsilon, Quaternion, Vector3 } from '../src'
 import { Matrix } from '../src/Matrix'
 
 const results = {
@@ -21,5 +22,36 @@ function matrixToString(m: Matrix.ReadonlyMatrix) {
 describe('ECS Matrix - Next tests', () => {
   it('Matrix.create One', () => {
     expect(matrixToString(Matrix.Identity())).toEqual(results.identity)
+  })
+
+  let tOut: Vector3
+  let sOut: Vector3
+  let rOut: Quaternion
+
+  beforeEach(() => {
+    tOut = Vector3.create(NaN, NaN, NaN)
+    sOut = Vector3.create(NaN, NaN, NaN)
+    rOut = Quaternion.create(NaN, NaN, NaN, NaN)
+  })
+
+  it('Matrix.decompose common case', () => {
+    const t = Vector3.create(1, 2, 3)
+    const r = Quaternion.fromEulerDegrees(15, 25, 35)
+    const s = Vector3.create(2, 2, 2)
+    const m = Matrix.compose(s, r, t)
+    expect(Matrix.decompose(m, sOut, rOut, tOut)).toBe(true)
+    expect(Vector3.equalsWithEpsilon(t, tOut)).toBe(true)
+    expect(Vector3.equalsWithEpsilon(s, sOut)).toBe(true)
+    expect(Math.abs(Quaternion.angle(r, rOut)) < Epsilon).toBe(true)
+  })
+
+  it('Matrix.decompose identity case', () => {
+    expect(Matrix.decompose(Matrix.Identity(), sOut, rOut, tOut)).toBe(true)
+    expect(Vector3.equalsWithEpsilon(tOut, Vector3.Zero())).toBe(true)
+    expect(Vector3.equalsWithEpsilon(sOut, Vector3.One())).toBe(true)
+    expect(
+      Math.abs(Quaternion.angle(rOut, Quaternion.fromEulerDegrees(0, 0, 0))) <
+        Epsilon
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
Matrix.decompose did not set mutable input vector's fields for translation. In case of identity matrix it didn't set fields for scale and rotation inputs too.